### PR TITLE
More stable elevation

### DIFF
--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -24,10 +24,6 @@ var yes_no_bool = function (x) {
     return "No";
 }
 
-const sleep = (duration) => {
-  return new Promise(resolve => setTimeout(resolve, duration));
-}
-
 module.exports = kind({
   name: 'MainPanel',
   kind: Panel,

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -106,7 +106,7 @@ module.exports = kind({
     this.inherited(arguments);
     console.info("Application created");
     this.set('resultText', 'Waiting for startup...');
-    // Spawn startup routine after 2 seconds, so UI has time to load
+    // Spawn startup routine after 3 seconds, so UI has time to load
     var self = this;
     setTimeout(function() {
       self.doStartup();

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -80,8 +80,7 @@ module.exports = kind({
     {kind: LunaService, name: 'terminate', service: 'luna://org.webosbrew.hyperhdr.loader.service', method: 'terminate', onResponse: 'onTermination', onError: 'onTermination'},
     {kind: LunaService, name: 'autostartStatusCheck', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onAutostartCheck', onError: 'onAutostartCheck'},
 
-    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'},
-    {kind: LunaService, name: 'systemReboot', service: 'luna://org.webosbrew.hbchannel.service', method: 'reboot'},
+    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'}
   ],
 
   autostartEnabled: false,
@@ -122,7 +121,7 @@ module.exports = kind({
   },
   reboot: function () {
     console.info("Sending reboot command");
-    this.$.systemReboot.send({reason: 'SwDownload'});
+    this.$.exec.send({command: 'reboot'});
   },
   start: function () {
     console.info("Start clicked");

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -76,7 +76,8 @@ module.exports = kind({
     {kind: LunaService, name: 'terminate', service: 'luna://org.webosbrew.hyperhdr.loader.service', method: 'terminate', onResponse: 'onTermination', onError: 'onTermination'},
     {kind: LunaService, name: 'autostartStatusCheck', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onAutostartCheck', onError: 'onAutostartCheck'},
 
-    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'}
+    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'},
+    {kind: LunaService, name: 'systemReboot', service: 'luna://org.webosbrew.hbchannel.service', method: 'reboot' }
   ],
 
   autostartEnabled: false,
@@ -129,7 +130,7 @@ module.exports = kind({
   },
   reboot: function () {
     console.info("Sending reboot command");
-    this.$.exec.send({command: 'reboot'});
+    this.$.systemReboot.send({});
   },
   start: function () {
     console.info("Start clicked");


### PR DESCRIPTION
- Continously poll for status message
- Use a little delay before sending off first luna-service request
- Fix: reboot breaking WiFi functionality by using hbchannel.reboot with empty payload `{}` instead of `{reason: 'SwUpdate'}` (webOS 3.x)
- Fix: JS compatibility - `let` -> `var`, remove unused `const`-function (webOS 3.x)