### PR TITLE
Add commits count

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         working-directory: ./hyperhdr-repo
 
     steps:
+    
       - uses: actions/checkout@v3
         with:
           repository: awawa-dev/HyperHDR
@@ -31,6 +32,14 @@ jobs:
           path: hyperhdr-repo
           submodules: recursive
           fetch-depth: 0
+      
+      - name: Extract version from package.json
+        uses: sergeysova/jq-action@v2
+        id: version
+        with:
+          cmd: 
+            echo "$( jq --arg ver $(cat ./version) '.version = $ver' appinfo.json )"
+            cat ./appinfo.json
 
       - name: Restore/Cache build directories
         uses: actions/cache@v3
@@ -113,8 +122,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: hyperhdr-build
-          path: ${{ github.workspace }}/hyperhdr-repo/release/*
+          path: |
+            ${{ github.workspace }}/hyperhdr-repo/release/*
+            ./version
           if-no-files-found: error
+
+          
 
   build_ipk:
     runs-on: ubuntu-latest
@@ -129,6 +142,13 @@ jobs:
         with:
           name: hyperhdr-build
           path: hyperhdr-build
+      
+      - name: Extract version from package.json
+        uses: sergeysova/jq-action@v2
+        id: version
+        with:
+          cmd: 
+            echo "$( jq --arg ver $(cat ./version) '.version = $ver' appinfo.json )"
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   build_hyperhdr:
     runs-on: ubuntu-latest
+    outputs:
+      commits-count: ${{ steps.version.outputs.commits-count }}
     defaults:
       run:
         working-directory: ./hyperhdr-repo
@@ -40,6 +42,9 @@ jobs:
           cmd: 
             echo "$( jq --arg ver $(cat ./version) '.version = $ver' appinfo.json )"
             cat ./appinfo.json
+
+      - id: version
+        run: echo "commits-count=$(git log --oneline | wc -l)" >> $GITHUB_OUTPUT
 
       - name: Restore/Cache build directories
         uses: actions/cache@v3
@@ -134,9 +139,16 @@ jobs:
     needs: build_hyperhdr
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
+
+      - id: version
+        run: echo "commits-count=$(git log --oneline | wc -l)" >> $GITHUB_OUTPUT
+
+      - id: apk_version
+        run: echo "value=0.${{steps.version.outputs.commits-count}}.${{needs.build_hyperhdr.outputs.commits-count}}" >> $GITHUB_OUTPUT
 
       - uses: actions/download-artifact@v3
         with:
@@ -152,6 +164,20 @@ jobs:
 
       - name: Display structure of downloaded files
         run: ls -R
+
+      - name: Update appinfo.json version from hyperhdr-build
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: appinfo.json
+          field: version
+          value: ${{steps.apk_version.outputs.value}}
+
+      - name: Update package.json version from hyperhdr-build
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: package.json
+          field: version
+          value: ${{steps.apk_version.outputs.value}}
 
       - name: Setup Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
Hello! Thanks for great project :)

I've noticed that in home-brew store hyperhdr version is a bit outdated and also #7 #8
This PR changes loader versioning, it will generate ipk version using following pattern `0.[commit count in loader repo].[commits count in hypehdr repo]` example: `0.85.204` This will ensure that every release/build will advance version, so home-brew store will allow users to update

ps initially I've tried to use [version](https://github.com/awawa-dev/HyperHDR/blob/master/version)  from hyperhdr repo, but it doesn't comply strict webos package versioning rules (3 integers divided by dot) example: `1.2.3` and Hyperion uses extended notation including number of beta `19.0.0.0beta2`
<img width="1022" alt="Screenshot 2022-12-06 at 08 32 56" src="https://user-images.githubusercontent.com/1525421/205860608-1f895517-701a-4c1b-8de8-39eddf55d223.png">

