### PR TITLE
CI: Poll HyperHDR repo daily for new tags, create PR if new tag is found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: awawa-dev/HyperHDR
-          ref: master
+          ref: 19.0.0.0beta2
           path: hyperhdr-repo
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: awawa-dev/HyperHDR
-          ref: 19.0.0.0beta2
+          ref: v19.0.0.0beta2
           path: hyperhdr-repo
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/poll_hyperhdr_tag.yml
+++ b/.github/workflows/poll_hyperhdr_tag.yml
@@ -16,7 +16,7 @@ jobs:
         id: read-tag
         run: echo value=$(yq -r .jobs.build_hyperhdr.steps[0].with.ref ./.github/workflows/build.yml) >> $GITHUB_OUTPUT
       - name: Print out gathered tag
-        run: echo "Current tag=${{ env.hyperhdr_ref }}"
+        run: echo "Current tag=${{ steps.read-tag.outputs.value }}"
 
   remote_tag:
     runs-on: ubuntu-latest
@@ -32,6 +32,8 @@ jobs:
       - name: Get latest tag of HyperHDR
         id: read-tag
         run: echo value=$(git describe --tags --abbrev=0) >> $GITHUB_OUTPUT
+      - name: Print out gathered tag
+        run: echo "Current tag=${{ steps.read-tag.outputs.value }}"
   
   create_pull_request:
     runs-on: ubuntu-latest

--- a/.github/workflows/poll_hyperhdr_tag.yml
+++ b/.github/workflows/poll_hyperhdr_tag.yml
@@ -1,0 +1,66 @@
+name: Poll HyperHDR (Pre-)releases
+on:
+  schedule:
+    # Runs at 00:00 UTC everyday
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  local_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.read-tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Read current tag from CI workflow
+        id: read-tag
+        run: echo value=$(yq -r .jobs.build_hyperhdr.steps[0].with.ref ./.github/workflows/build.yml) >> $GITHUB_OUTPUT
+      - name: Print out gathered tag
+        run: echo "Current tag=${{ env.hyperhdr_ref }}"
+
+  remote_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.read-tag.outputs.value }}
+    steps:
+      - name: Checkout HyperHDR repo
+        uses: actions/checkout@v3
+        with:
+          repository: awawa-dev/HyperHDR
+          submodules: recursive
+          fetch-depth: 0
+      - name: Get latest tag of HyperHDR
+        id: read-tag
+        run: echo value=$(git describe --tags --abbrev=0) >> $GITHUB_OUTPUT
+  
+  create_pull_request:
+    runs-on: ubuntu-latest
+    needs: [local_tag, remote_tag]
+    if: ${{ needs.local_tag.outputs.tag != needs.remote_tag.outputs.tag }}
+    steps:
+      - name: Assemble PR branch name
+        run: echo "pr_branch=update_daemon/${{ needs.remote_tag.outputs.tag }}" >> $GITHUB_ENV
+      - name: Check if PR already exists by attempting to checkout branch
+        continue-on-error: true
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.pr_branch }}
+      - name: Check if PR branch cloned
+        run: |
+          sh -c 'if [[ -f package.json ]]; then echo "PR already exists"; exit 1; fi'
+      - name: Clone master branch
+        uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Inject latest tag into CI workflow file
+        run: sed -i 's/${{ needs.local_tag.outputs.tag }}/${{ needs.remote_tag.outputs.tag }}/' ./.github/workflows/build.yml
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          add-paths: .github/workflows/build.yml
+          title: [Daemon] Bump to ${{ needs.remote_tag.outputs.tag }}
+          commit-message: [Daemon] Bump to ${{ needs.remote_tag.outputs.tag }}
+          branch: ${{ env.pr_branch }}
+          delete-branch: true
+      

--- a/.github/workflows/poll_hyperhdr_tag.yml
+++ b/.github/workflows/poll_hyperhdr_tag.yml
@@ -59,8 +59,8 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           add-paths: .github/workflows/build.yml
-          title: [Daemon] Bump to ${{ needs.remote_tag.outputs.tag }}
-          commit-message: [Daemon] Bump to ${{ needs.remote_tag.outputs.tag }}
+          title: "[Daemon] Bump HyperHDR to ${{ needs.remote_tag.outputs.tag }}"
+          commit-message: "[Daemon] Bump HyperHDR to ${{ needs.remote_tag.outputs.tag }}"
           branch: ${{ env.pr_branch }}
           delete-branch: true
       


### PR DESCRIPTION
This PR should periodically check HyperHDR if new tags are available. If a new tag is found, the pinned version in CI workflow `build.yml` is updated and a PR gets created.

If PR finishes building it can be merged and version needs to be bumped / tag needs to be created.

I found it safer to do it this way, so that PR does not rewrite the package.json on its own and possibly create conflicts.

Any input appreciated.