### PR TITLE
V21 beta 1 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,6 @@ jobs:
           chmod +x ./dist/service/start_hyperhdr
 
           chmod +x ./dist/service/hyperhdr/hyperhdr
-          chmod +x ./dist/service/hyperhdr/hyperhdr-remote
 
       - name: Copy HDR LUT
         run: unxz -dc ./resources/flat_lut_lin_tables.3d.xz > ./dist/service/hyperhdr/flat_lut_lin_tables.3d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: awawa-dev/HyperHDR
-          ref: v20.0.0.0
+          ref: v21.0.0.0beta1
           path: hyperhdr-repo
           submodules: recursive
           fetch-depth: 0

--- a/appinfo.json
+++ b/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "org.webosbrew.hyperhdr.loader",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "vendor": "webosbrew.org",
   "title": "HyperHDR",
   "icon": "assets/logo_small.png",

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ do
   chmod +x ${FILE}
 done
 
-for file in hyperhdr hyperhdr-remote flatc flathash
+for file in hyperhdr flatc flathash
 do
   FILE="${EXEC_DIR}/dist/service/hyperhdr/${file}"
   echo "=> ${FILE}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "org.webosbrew.hyperhdr.loader",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.webosbrew.hyperhdr.loader",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "HyperHDR loader",
   "main": "frontend/index.js",
   "moduledir": "frontend",


### PR DESCRIPTION
`hyperhdr-remote` is no longer available and was removed in https://github.com/awawa-dev/HyperHDR/commit/60aee23a5f06ba000983456a5b3ff3c279a81aa9

Update our buildscripts to no longer try to make it executable